### PR TITLE
Feature/registro login de usuarios con jwt

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: featureflag
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: P05t6r3SQL_1994
+    ports:
+      - "5433:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+volumes:
+  pgdata:

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,10 @@
 			<version>5.19.0</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,10 @@
 			<version>0.11.5</version>
 			<scope>runtime</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/bytescolab/featureflag/controller/AuthController.java
+++ b/src/main/java/com/bytescolab/featureflag/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.bytescolab.featureflag.controller;
 
+import com.bytescolab.featureflag.dto.auth.LoginDTO;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -28,6 +29,16 @@ public class AuthController {
     public ResponseEntity<AuthResponseDTO> register(@Valid @RequestBody RegisterDTO dto) {
         // El controller NO sabe de JPA ni seguridad: delega en el servicio (DIP)
         return ResponseEntity.ok(auth.register(dto));
+    }
+
+    @PostMapping("/login")
+    @Operation(
+            summary = "Login",
+            description = "Valida credenciales y devuelve un JWT (Bearer) con la expiración y el rol"
+    )
+    public ResponseEntity<AuthResponseDTO> login(@Valid @RequestBody LoginDTO dto) {
+        // Delegamos en el servicio: él usa AuthenticationManager (BCrypt) y JwtUtils para emitir el token
+        return ResponseEntity.ok(auth.login(dto));
     }
     //Login
     //@PostMapping login ("/login")

--- a/src/main/java/com/bytescolab/featureflag/controller/AuthController.java
+++ b/src/main/java/com/bytescolab/featureflag/controller/AuthController.java
@@ -3,10 +3,32 @@ package com.bytescolab.featureflag.controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.bytescolab.featureflag.dto.auth.RegisterDTO;
+import com.bytescolab.featureflag.dto.auth.AuthResponseDTO;
+import com.bytescolab.featureflag.service.auth.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
 @RestController
 @RequestMapping("/api/auth")
+@Tag(name = "Auth", description = "Authentication endpoints")
+@RequiredArgsConstructor // ← Lombok genera constructor para el 'final' de abajo
 public class AuthController {
 
+    // ⚠️ Importante: 'final' + @RequiredArgsConstructor evita el error “Field 'auth' might not have been initialized”
+    private final AuthService auth;
+
+
+    @PostMapping("/register")
+    @Operation(summary = "Register a new user", description = "Creates a user with default role USER")
+    public ResponseEntity<AuthResponseDTO> register(@Valid @RequestBody RegisterDTO dto) {
+        // El controller NO sabe de JPA ni seguridad: delega en el servicio (DIP)
+        return ResponseEntity.ok(auth.register(dto));
+    }
     //Login
     //@PostMapping login ("/login")
     //FIN Login

--- a/src/main/java/com/bytescolab/featureflag/dto/auth/AuthResponseDTO.java
+++ b/src/main/java/com/bytescolab/featureflag/dto/auth/AuthResponseDTO.java
@@ -1,4 +1,17 @@
 package com.bytescolab.featureflag.dto.auth;
 
+import lombok.*;
+
+import java.util.UUID;
+
+// Respuesta "segura": no devolvemos password
+@Getter @Setter @AllArgsConstructor @Builder
 public class AuthResponseDTO {
+    private String accessToken;
+    private long expiresAt;
+    @Builder.Default
+    private String tokenType = "Bearer";
+    private UUID id;
+    private String username;
+    private String role;
 }

--- a/src/main/java/com/bytescolab/featureflag/dto/auth/LoginDTO.java
+++ b/src/main/java/com/bytescolab/featureflag/dto/auth/LoginDTO.java
@@ -1,4 +1,13 @@
 package com.bytescolab.featureflag.dto.auth;
 
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
 public class LoginDTO {
+    @NotBlank(message = "username is required")
+    private String username;
+
+    @NotBlank(message = "password is required")
+    private String password;
 }

--- a/src/main/java/com/bytescolab/featureflag/dto/auth/RegisterDTO.java
+++ b/src/main/java/com/bytescolab/featureflag/dto/auth/RegisterDTO.java
@@ -1,4 +1,19 @@
 package com.bytescolab.featureflag.dto.auth;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import lombok.*;
+
+// Lombok genera getters/setters/constructores (menos código)
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
 public class RegisterDTO {
+    // Validamos entrada desde el propio contrato (Bean Validation)
+    @NotBlank(message = "username is required")
+    @Size(min = 3, max = 30, message = "username must be 3-50 chars")
+    private String username;
+
+    @NotBlank(message = "password is required")
+    @Size(min = 6, message = "password must be at least 8 chars") // nunca aceptes contraseñas triviales
+    private String password;
 }

--- a/src/main/java/com/bytescolab/featureflag/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bytescolab/featureflag/exception/GlobalExceptionHandler.java
@@ -2,12 +2,16 @@ package com.bytescolab.featureflag.exception;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -26,13 +30,41 @@ public class GlobalExceptionHandler {
         return buildResponse(HttpStatus.UNAUTHORIZED, ex.getMessage());
     }
 
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Object> handleValidation(MethodArgumentNotValidException ex){
+        Map<String, String> fields = ex.getBindingResult().getFieldErrors().stream()
+                .collect(Collectors.toMap(FieldError::getField, f -> f.getDefaultMessage(), (a, b)->a));
+        Map<String, Object> body = base(HttpStatus.BAD_REQUEST, "Validation failed");
+        body.put("validation", fields);
+        return new ResponseEntity<>(body, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(BadCredentialsException.class)
+    public ResponseEntity<Object> handleBadCreds(BadCredentialsException ex){
+        return buildResponse(HttpStatus.UNAUTHORIZED, "Invalid username or password");
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Object> handleIllegalArg(IllegalArgumentException ex) {
+        Map<String,Object> body = new HashMap<>();
+        body.put("timestamp", java.time.Instant.now().toString());
+        body.put("status", 409);
+        body.put("error", "Conflict");
+        body.put("message", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
+    }
+
     private ResponseEntity<Object> buildResponse (HttpStatus status, String message){
-        Map<String, Object> body = new HashMap<>();
+        return new ResponseEntity<>(base(status, message), status);
+    }
+
+    private Map<String,Object> base(HttpStatus status, String message){
+        Map<String,Object> body = new HashMap<>();
         body.put("timestamp", LocalDateTime.now());
         body.put("status", status.value());
         body.put("error", status.getReasonPhrase());
         body.put("message", message);
-        return new ResponseEntity<>(body, status);
+        return body;
     }
 
 }

--- a/src/main/java/com/bytescolab/featureflag/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bytescolab/featureflag/exception/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.time.LocalDateTime;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -22,7 +23,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(TokenInvalidoException.class)
-    public ResponseEntity<Object> handleTokenInvalido(TokenExpiradoException ex){
+    public ResponseEntity<Object> handleTokenInvalido(TokenInvalidoException ex){
         return buildResponse(HttpStatus.FORBIDDEN, ex.getMessage());
     }
     @ExceptionHandler(TokenMalFormadoException.class)
@@ -32,8 +33,9 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Object> handleValidation(MethodArgumentNotValidException ex){
-        Map<String, String> fields = ex.getBindingResult().getFieldErrors().stream()
-                .collect(Collectors.toMap(FieldError::getField, f -> f.getDefaultMessage(), (a, b)->a));
+        Map<String, String> fields = new LinkedHashMap<>();
+        ex.getBindingResult().getFieldErrors()
+                .forEach(fe -> fields.putIfAbsent(fe.getField(), fe.getDefaultMessage()));
         Map<String, Object> body = base(HttpStatus.BAD_REQUEST, "Validation failed");
         body.put("validation", fields);
         return new ResponseEntity<>(body, HttpStatus.BAD_REQUEST);

--- a/src/main/java/com/bytescolab/featureflag/model/entity/User.java
+++ b/src/main/java/com/bytescolab/featureflag/model/entity/User.java
@@ -4,11 +4,32 @@ import com.bytescolab.featureflag.model.enums.Role;
 
 import java.util.UUID;
 
+import jakarta.persistence.*;
+
+import lombok.*;
+
+@Entity                     // ← esta clase es una tabla
+@Table(name = "users")      // ← nombre explícito
+@Getter
+@Setter
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class User {
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
+
+    @Column(nullable = false, unique = true)
     private String username;
+
+    @Column(nullable = false)
     private String password;
-    private Role rol;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
 
 }

--- a/src/main/java/com/bytescolab/featureflag/security/config/SecurityConfig.java
+++ b/src/main/java/com/bytescolab/featureflag/security/config/SecurityConfig.java
@@ -10,9 +10,12 @@ import org.springframework.security.config.annotation.authentication.configurati
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
 @EnableWebSecurity
@@ -23,10 +26,19 @@ public class SecurityConfig {
     private final JwtFilter jwtFilter;
 
     @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
+                .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/api/auth/**",
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html").permitAll()
                         .anyRequest().authenticated()
                 )
                 .sessionManagement(session -> session

--- a/src/main/java/com/bytescolab/featureflag/security/config/SecurityConfig.java
+++ b/src/main/java/com/bytescolab/featureflag/security/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.bytescolab.featureflag.security.config;
 
 
+import com.bytescolab.featureflag.security.handlers.RestAuthenticationEntryPoint;
 import com.bytescolab.featureflag.security.jwt.JwtFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -12,10 +13,11 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.DefaultSecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import com.bytescolab.featureflag.security.handlers.RestAccessDeniedHandler;
 
 @Configuration
 @EnableWebSecurity
@@ -24,6 +26,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 public class SecurityConfig {
 
     private final JwtFilter jwtFilter;
+    private final RestAccessDeniedHandler accessDeniedHandler;
+    private final RestAuthenticationEntryPoint authenticationEntryPoint;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -31,21 +35,26 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        return http
+    public DefaultSecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**",
                                 "/v3/api-docs/**",
                                 "/swagger-ui/**",
-                                "/swagger-ui.html").permitAll()
+                                "/swagger-ui.html",
+                                "/error" ).permitAll()
                         .anyRequest().authenticated()
                 )
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
-                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
-                .build();
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler) // 403 JSON aquí
+                );
+        http.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+        return http.build();
     }
 
     @Bean

--- a/src/main/java/com/bytescolab/featureflag/security/handlers/RestAccessDeniedHandler.java
+++ b/src/main/java/com/bytescolab/featureflag/security/handlers/RestAccessDeniedHandler.java
@@ -1,0 +1,28 @@
+package com.bytescolab.featureflag.security.handlers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Map;
+
+@Component
+public class RestAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest req, HttpServletResponse res, AccessDeniedException ex) throws IOException {
+        res.setStatus(HttpStatus.FORBIDDEN.value());
+        res.setContentType("application/json");
+        var body = Map.of(
+                "timestamp", Instant.now().toString(),
+                "status", HttpStatus.FORBIDDEN.value(),
+                "error", "Forbidden",
+                "message", "You do not have permission to access this resource",
+                "path", req.getRequestURI()
+        );
+        new ObjectMapper().writeValue(res.getOutputStream(), body);
+    }
+}

--- a/src/main/java/com/bytescolab/featureflag/security/handlers/RestAuthenticationEntryPoint.java
+++ b/src/main/java/com/bytescolab/featureflag/security/handlers/RestAuthenticationEntryPoint.java
@@ -1,0 +1,30 @@
+package com.bytescolab.featureflag.security.handlers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Map;
+
+@Component
+public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest req, HttpServletResponse res, AuthenticationException ex) throws IOException {
+        res.setStatus(HttpStatus.UNAUTHORIZED.value());
+        res.setContentType("application/json");
+        var body = Map.of(
+                "timestamp", Instant.now().toString(),
+                "status", HttpStatus.UNAUTHORIZED.value(),
+                "error", "Unauthorized",
+                "message", "Authentication is required to access this resource",
+                "path", req.getRequestURI()
+        );
+        new ObjectMapper().writeValue(res.getOutputStream(), body);
+    }
+}
+

--- a/src/main/java/com/bytescolab/featureflag/security/jwt/JwtFilter.java
+++ b/src/main/java/com/bytescolab/featureflag/security/jwt/JwtFilter.java
@@ -1,6 +1,5 @@
 package com.bytescolab.featureflag.security.jwt;
 
-//import com.bytescolab.featureflag.service.user.UserDetailsService;
 import org.springframework.security.core.userdetails.UserDetailsService;
 
 import com.bytescolab.featureflag.exception.TokenExpiradoException;
@@ -33,6 +32,12 @@ public class JwtFilter extends OncePerRequestFilter {
                                     HttpServletResponse response,
                                     FilterChain filterChain)
             throws ServletException, IOException {
+
+        final String uri = request.getRequestURI();
+        if (uri.startsWith("/api/auth/")) {
+            filterChain.doFilter(request, response);
+            return; // ⬅ importante: solo una pasada
+        }
         //Se recoge el token de las cabeceras
         final String authHeader = request.getHeader("Authorization");
         log.info("Recogemos el token {}", authHeader );
@@ -71,18 +76,21 @@ public class JwtFilter extends OncePerRequestFilter {
                     log.error("Token no válido para usuario {}", username);
                 }
             }
-
+           // filterChain.doFilter(request, response);
         } catch (TokenExpiradoException e) {
             log.error("Token expirado: {}", e.getMessage());
-            throw new TokenExpiradoException("El token ha expirado");
+            //throw new TokenExpiradoException("El token ha expirado");
+            SecurityContextHolder.clearContext();
         } catch (TokenMalFormadoException e) {
             log.error("Token mal formado: {}", e.getMessage());
-            throw new TokenMalFormadoException("El token está mal formado");
+            //throw new TokenMalFormadoException("El token está mal formado");
+            SecurityContextHolder.clearContext();
         } catch (TokenInvalidoException e) {
             log.error("Error al validar el token JWT: {}", e.getMessage());
-            throw new TokenInvalidoException("El token no ha podido ser validado.");
+            SecurityContextHolder.clearContext();
+            //throw new TokenInvalidoException("El token no ha podido ser validado.");
         }
 
-        filterChain.doFilter(request, response);
+
     }
 }

--- a/src/main/java/com/bytescolab/featureflag/security/jwt/JwtFilter.java
+++ b/src/main/java/com/bytescolab/featureflag/security/jwt/JwtFilter.java
@@ -1,6 +1,8 @@
 package com.bytescolab.featureflag.security.jwt;
 
-import com.bytescolab.featureflag.service.user.UserDetailsService;
+//import com.bytescolab.featureflag.service.user.UserDetailsService;
+import org.springframework.security.core.userdetails.UserDetailsService;
+
 import com.bytescolab.featureflag.exception.TokenExpiradoException;
 import com.bytescolab.featureflag.exception.TokenInvalidoException;
 import com.bytescolab.featureflag.exception.TokenMalFormadoException;

--- a/src/main/java/com/bytescolab/featureflag/security/jwt/JwtUtils.java
+++ b/src/main/java/com/bytescolab/featureflag/security/jwt/JwtUtils.java
@@ -1,5 +1,8 @@
 package com.bytescolab.featureflag.security.jwt;
 
+import com.bytescolab.featureflag.exception.TokenExpiradoException;
+import com.bytescolab.featureflag.exception.TokenInvalidoException;
+import com.bytescolab.featureflag.exception.TokenMalFormadoException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
@@ -32,12 +35,20 @@ public class JwtUtils {
     }
 
     public String extractUsername(String token) {
-        return Jwts.parserBuilder()
-                .setSigningKey(getSigningKey())
-                .build()
-                .parseClaimsJws(token)
-                .getBody()
-                .getSubject();
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(getSigningKey())
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody()
+                    .getSubject();
+        } catch (ExpiredJwtException e) {
+            throw new TokenExpiradoException("El token ha expirado");
+        } catch (MalformedJwtException | UnsupportedJwtException e) {
+            throw new TokenMalFormadoException("Token mal formado");
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new TokenInvalidoException("Token inválido");
+        }
     }
 
     public boolean isTokenValid(String token, UserDetails userDetails) {
@@ -55,19 +66,28 @@ public class JwtUtils {
         return expiration.before(new Date());
     }
 
-    private SecretKey getSigningKey(){
+    private SecretKey getSigningKey() {
 //        byte[] keyBytes = Base64.getDecoder().decode(jwtSecret);
 //        return Keys.hmacShaKeyFor(keyBytes);
         return Keys.hmacShaKeyFor(jwtSecret.getBytes(StandardCharsets.UTF_8));
 
     }
+
     public long extractExpirationMillis(String token) {
-        return Jwts.parserBuilder()
-                .setSigningKey(getSigningKey())
-                .build()
-                .parseClaimsJws(token)
-                .getBody()
-                .getExpiration()
-                .getTime();
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(getSigningKey())
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody()
+                    .getExpiration()
+                    .getTime();
+        } catch (ExpiredJwtException e) {
+            throw new TokenExpiradoException("El token ha expirado");
+        } catch (MalformedJwtException | UnsupportedJwtException e) {
+            throw new TokenMalFormadoException("Token mal formado");
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new TokenInvalidoException("Token inválido");
+        }
     }
 }

--- a/src/main/java/com/bytescolab/featureflag/security/jwt/JwtUtils.java
+++ b/src/main/java/com/bytescolab/featureflag/security/jwt/JwtUtils.java
@@ -8,6 +8,7 @@ import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 
 import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Date;
 
@@ -55,7 +56,18 @@ public class JwtUtils {
     }
 
     private SecretKey getSigningKey(){
-        byte[] keyBytes = Base64.getDecoder().decode(jwtSecret);
-        return Keys.hmacShaKeyFor(keyBytes);
+//        byte[] keyBytes = Base64.getDecoder().decode(jwtSecret);
+//        return Keys.hmacShaKeyFor(keyBytes);
+        return Keys.hmacShaKeyFor(jwtSecret.getBytes(StandardCharsets.UTF_8));
+
+    }
+    public long extractExpirationMillis(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getExpiration()
+                .getTime();
     }
 }

--- a/src/main/java/com/bytescolab/featureflag/service/auth/AuthService.java
+++ b/src/main/java/com/bytescolab/featureflag/service/auth/AuthService.java
@@ -1,4 +1,8 @@
 package com.bytescolab.featureflag.service.auth;
 
+import com.bytescolab.featureflag.dto.auth.AuthResponseDTO;
+import com.bytescolab.featureflag.dto.auth.RegisterDTO;
+
 public interface AuthService {
+    AuthResponseDTO register(RegisterDTO dto);
 }

--- a/src/main/java/com/bytescolab/featureflag/service/auth/AuthService.java
+++ b/src/main/java/com/bytescolab/featureflag/service/auth/AuthService.java
@@ -1,8 +1,10 @@
 package com.bytescolab.featureflag.service.auth;
 
 import com.bytescolab.featureflag.dto.auth.AuthResponseDTO;
+import com.bytescolab.featureflag.dto.auth.LoginDTO;
 import com.bytescolab.featureflag.dto.auth.RegisterDTO;
 
 public interface AuthService {
     AuthResponseDTO register(RegisterDTO dto);
+    AuthResponseDTO login(LoginDTO dto);
 }

--- a/src/main/java/com/bytescolab/featureflag/service/auth/AuthServiceImpl.java
+++ b/src/main/java/com/bytescolab/featureflag/service/auth/AuthServiceImpl.java
@@ -1,14 +1,21 @@
 package com.bytescolab.featureflag.service.auth;
 
+import com.bytescolab.featureflag.dto.auth.LoginDTO;
 import com.bytescolab.featureflag.dto.auth.RegisterDTO;
 import com.bytescolab.featureflag.dto.auth.AuthResponseDTO;
 import com.bytescolab.featureflag.model.entity.User;
 import com.bytescolab.featureflag.model.enums.Role;
 import com.bytescolab.featureflag.repository.UserRepository;
+import com.bytescolab.featureflag.security.auth.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.authentication.AuthenticationManager;
+import com.bytescolab.featureflag.security.jwt.JwtUtils;
 
 @Service
 @RequiredArgsConstructor // inyecta repositorio y encoder por constructor
@@ -16,6 +23,11 @@ public class AuthServiceImpl implements AuthService {
 
     private final UserRepository users;
     private final PasswordEncoder encoder; // BCrypt (lo definimos en SecurityConfig)
+    // 👇 NUEVO (lo usa login() para validar credenciales con Spring Security)
+    private final AuthenticationManager authenticationManager;
+
+    // 👇 NUEVO (lo usa login() para emitir el JWT)
+    private final JwtUtils jwtUtils;
 
     @Override
     @Transactional
@@ -37,10 +49,39 @@ public class AuthServiceImpl implements AuthService {
 
         // 4) Guardamos y devolvemos DTO de salida sin campos sensibles
         User saved = users.save(u);
+        // Construye un UserDetails para emitir el token; puedes reusar tu CustomUserDetails
+        UserDetails details = new CustomUserDetails(saved);
+
+        String token = jwtUtils.generateToken(details);
+        long expMillis = jwtUtils.extractExpirationMillis(token);
         return AuthResponseDTO.builder()
                 .id(saved.getId())
                 .username(saved.getUsername())
                 .role(saved.getRole().name())
+                .accessToken(token)        // <- ya no es null
+                .expiresAt(expMillis)      // <- ya no es 0
+                .tokenType("Bearer")
+                .build();
+    }
+
+    @Override
+    public AuthResponseDTO login(LoginDTO dto) {
+        Authentication auth = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(dto.getUsername(), dto.getPassword())
+        );
+
+        UserDetails principal = (UserDetails) auth.getPrincipal();
+        String role = principal.getAuthorities().iterator().next().getAuthority().replace("ROLE_", "");
+
+        String token = jwtUtils.generateToken(principal);
+        long expMillis = jwtUtils.extractExpirationMillis(token);
+
+        return AuthResponseDTO.builder()
+                .accessToken(token)
+                .expiresAt(expMillis)
+                .tokenType("Bearer")
+                .username(principal.getUsername())
+                .role(role)
                 .build();
     }
 }

--- a/src/main/java/com/bytescolab/featureflag/service/auth/AuthServiceImpl.java
+++ b/src/main/java/com/bytescolab/featureflag/service/auth/AuthServiceImpl.java
@@ -1,4 +1,46 @@
 package com.bytescolab.featureflag.service.auth;
 
-public class AuthServiceImpl {
+import com.bytescolab.featureflag.dto.auth.RegisterDTO;
+import com.bytescolab.featureflag.dto.auth.AuthResponseDTO;
+import com.bytescolab.featureflag.model.entity.User;
+import com.bytescolab.featureflag.model.enums.Role;
+import com.bytescolab.featureflag.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor // inyecta repositorio y encoder por constructor
+public class AuthServiceImpl implements AuthService {
+
+    private final UserRepository users;
+    private final PasswordEncoder encoder; // BCrypt (lo definimos en SecurityConfig)
+
+    @Override
+    @Transactional
+    public AuthResponseDTO register(RegisterDTO dto) {
+        // 1) Regla: username único
+        if (users.existsByUsername(dto.getUsername())) {
+            throw new IllegalArgumentException("Username already taken");
+        }
+
+        // 2) Nunca se debe guardar password en claro → usa el hash
+        String hash = encoder.encode(dto.getPassword());
+
+        // 3) Construimos la entidad con rol por defecto USER (evita escaladas)
+        User u = User.builder()
+                .username(dto.getUsername())
+                .password(hash)
+                .role(Role.USER)
+                .build();
+
+        // 4) Guardamos y devolvemos DTO de salida sin campos sensibles
+        User saved = users.save(u);
+        return AuthResponseDTO.builder()
+                .id(saved.getId())
+                .username(saved.getUsername())
+                .role(saved.getRole().name())
+                .build();
+    }
 }

--- a/src/main/java/com/bytescolab/featureflag/service/user/UserDetailsServiceImpl.java
+++ b/src/main/java/com/bytescolab/featureflag/service/user/UserDetailsServiceImpl.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.security.core.userdetails.UserDetailsService; // <-- este import
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,14 @@
 spring.application.name=featureflag
+spring.datasource.url=jdbc:postgresql://127.0.0.1:5433/featureflag
+spring.datasource.username=postgres
+spring.datasource.password=P05t6r3SQL_1994
+
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=false
+
+# Swagger / OpenAPI
+springdoc.api-docs.enabled=true
+
+# JWT
+security.jwt.secret=CHANGE_ME_SUPER_LONG_SECRET_32+CHARS
+security.jwt.expiration-min=60

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -3,7 +3,22 @@ jwt:
   expirationMs: 86400000
 
 server.port: 8080
-spring.security.user.name: admin
-spring.security.user.password: admin.
-jwt.secret: BytesColab4P!
-jwt.expiration: 3600000
+#spring.security.user.name: admin
+#spring.security.user.password: admin.
+#jwt.secret: BytesColab4P!
+#jwt.expiration: 3600000
+
+spring:
+  datasource:
+    url: jdbc:postgresql://127.0.0.1:5433/featureflag
+    username: postgres
+    password: P05t6r3SQL_1994
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: false
+
+# Swagger
+springdoc:
+  api-docs:
+    enabled: true


### PR DESCRIPTION
**feat(auth): registro+login con JWT y errores JSON**

**Endpoints de autenticación**

- Añadido POST /api/auth/login en AuthController y firma login(LoginDTO) en AuthService.

- Implementado AuthServiceImpl.login(...) con AuthenticationManager (BCrypt) y JwtUtils → devuelve accessToken, expiresAt, username, role.

- POST /api/auth/register ahora devuelve JWT tras crear usuario con rol USER por defecto.

**Seguridad (stateless)**

- SecurityConfig: permitAll("/api/auth/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html", "/error") + SessionCreationPolicy.STATELESS.

- Beans expuestos: PasswordEncoder (BCrypt) y AuthenticationManager.

- Handlers JSON: 401 → RestAuthenticationEntryPoint, 403 → RestAccessDeniedHandler.

**Filtro JWT**

- JwtFilter: whitelist /api/auth/**, ignora Authorization vacío ("Bearer "), una sola llamada a filterChain.doFilter(...) y delega errores a los handlers (no relanza).

- JwtUtils: HS256 con jwt.secret (≥32 chars), claim roles como List<String>, helper extractExpirationMillis(...).

**Manejo de errores**

- GlobalExceptionHandler: 400 (validación), 401 (BadCredentialsException), 409 (IllegalArgumentException por usuario duplicado) y corrección de tipos para TokenExpirado/TokenMalFormado/TokenInvalido.